### PR TITLE
WinRT Server fixes

### DIFF
--- a/src/Shmuelie.WinRTServer/Internal/BaseActivationFactoryWrapper.cs
+++ b/src/Shmuelie.WinRTServer/Internal/BaseActivationFactoryWrapper.cs
@@ -18,32 +18,18 @@ internal sealed partial class BaseActivationFactoryWrapper(BaseActivationFactory
             return HRESULT.E_INVALIDARG;
         }
 
-        bool shouldReleaseUnknown = false;
         nint unknown = 0;
         try
         {
             object managedInstance = factory.ActivateInstance();
             unknown = comWrappers.GetOrCreateComInterfaceForObject(managedInstance, CreateComInterfaceFlags.None);
-            var hr = (HRESULT)Marshal.QueryInterface(unknown, in global::Windows.Win32.System.WinRT.IActivationFactory.IID_Guid, out nint ppv);
-            shouldReleaseUnknown = true;
-            if (hr.Failed)
-            {
-                return hr;
-            }
-            *instance = (void*)ppv;
+            *instance = (void*)unknown;
 
             factory.OnInstanceCreated(managedInstance);
         }
         catch (Exception e)
         {
             return (HRESULT)Marshal.GetHRForException(e);
-        }
-        finally
-        {
-            if (shouldReleaseUnknown)
-            {
-                Marshal.Release(unknown);
-            }
         }
         return HRESULT.S_OK;
     }

--- a/src/Shmuelie.WinRTServer/WinRtServer.cs
+++ b/src/Shmuelie.WinRTServer/WinRtServer.cs
@@ -207,7 +207,7 @@ public sealed class WinRtServer : IAsyncDisposable
             Marshal.Release(unknown);
         }
 
-        return HRESULT.S_OK;
+        return hr;
     }
 
     /// <summary>

--- a/src/Shmuelie.WinRTServer/WinRtServer.cs
+++ b/src/Shmuelie.WinRTServer/WinRtServer.cs
@@ -199,7 +199,14 @@ public sealed class WinRtServer : IAsyncDisposable
             return HRESULT.E_NOINTERFACE;
         }
 
-        *factory = (IActivationFactory*)comWrappers.GetOrCreateComInterfaceForObject(new BaseActivationFactoryWrapper(managedFactory.Factory, managedFactory.Wrapper), CreateComInterfaceFlags.None);
+        var unknown = comWrappers.GetOrCreateComInterfaceForObject(new BaseActivationFactoryWrapper(managedFactory.Factory, managedFactory.Wrapper), CreateComInterfaceFlags.None);
+        var hr = (HRESULT)Marshal.QueryInterface(unknown, in global::Windows.Win32.System.WinRT.IActivationFactory.IID_Guid, out nint ppv);
+        *factory = (IActivationFactory*)ppv;
+        if (unknown != 0)
+        {
+            Marshal.Release(unknown);
+        }
+
         return HRESULT.S_OK;
     }
 


### PR DESCRIPTION
We ran into two problems trying to use WinRT server in .NET9. I'm not sure what changed/broke this but it seems obvious what's wrong:

1. WinRTServer was blindly casting the result of GetOrCreateComInterfaceForObject to IActivationFactory* but in NAOT the result was actually an IUnknown and we need to QI for IActivationFactory instead.
2. ActivateInstance was QI'ing the instance for IActivationFactory but instances will never implement this, so we should instead just return the interface out as-is.

I was able to reproduce the problem by publishing the test package and running the C++ app -- the background WinRT server crashes calling GetTrustLevel on what it thinks is an IActivationFactory but is actually an IUnknown. And once that is fixed (1), then the IActivationFactory QI in ActivateInstance failed. With these fixes, the NAOT compiled version succeeds.