### PR TITLE
Partially fix lifetime management

### DIFF
--- a/src/Shmuelie.WinRTServer/ComServer.cs
+++ b/src/Shmuelie.WinRTServer/ComServer.cs
@@ -189,6 +189,9 @@ public sealed class ComServer : IAsyncDisposable
         liveServers.AddLast(new WeakReference(e.Instance));
         InstanceCreated?.Invoke(this, e);
         firstInstanceCreated?.TrySetResult(e.Instance);
+
+        // Reset the TaskCompletionSource to avoid keeping a reference to the first instance created indefinitely.
+        firstInstanceCreated = new TaskCompletionSource<object>();
     }
 
     /// <summary>

--- a/src/Shmuelie.WinRTServer/CsWinRT/ComServerExtensions.cs
+++ b/src/Shmuelie.WinRTServer/CsWinRT/ComServerExtensions.cs
@@ -83,4 +83,16 @@ public static class ComServerExtensions
 
         return server.UnregisterClassFactory(factory.Clsid);
     }
+
+    /// <summary>
+    /// Get or create a CCW using the default ComWrappers object used by this extension class.
+    /// </summary>
+    /// <param name="managedObject">Managed object to create a CCW for.</param>
+    /// <exception cref="ArgumentNullException">The managed object being passed is null.</exception>
+    public static nint GetOrCreateComInterfaceForObject(object managedObject)
+    {
+        ArgumentNullException.ThrowIfNull(managedObject);
+        
+        return comWrappers.GetOrCreateComInterfaceForObject(managedObject, System.Runtime.InteropServices.CreateComInterfaceFlags.None);
+    }
 }


### PR DESCRIPTION
This PR does 2 things:
1) It "fixes" the lifetime management bug where initial managed server object was never destroyed becuase it was kept as result in `TaskCompletionSource` forever. That kept server running forever.
2) Added a `CreateCCW` method to `CsWinRT ComServerExtensions` to allow retrieval of `CCWs` created by this ComServer if needed.