### PR TITLE
Add WaitForEmptyAsync() method to ComServer and WinRtServer

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
+    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.4
+      with:
+        sdk-version: 22000
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: Setup NuGet
@@ -40,6 +43,9 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
+    - uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.4
+      with:
+        sdk-version: 22000
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: Setup NuGet

--- a/src/Shmuelie.WinRTServer/ComServer.cs
+++ b/src/Shmuelie.WinRTServer/ComServer.cs
@@ -18,14 +18,14 @@ namespace Shmuelie.WinRTServer;
 /// </summary>
 /// <remarks>
 /// <para>Allows for types to be created using COM activation instead of WinRT activation like <see cref="WinRtServer"/>.</para>
-/// <para>Typical usage is to call from an <see langword="await"/> <see langword="using"/> block, using <see cref="WaitForFirstObjectAsync"/> to not close until it is safe to do so.</para>
+/// <para>Typical usage is to call from an <see langword="await"/> <see langword="using"/> block, using <see cref="WaitForEmptyAsync"/> to not close until it is safe to do so.</para>
 /// <code language="cs">
 /// <![CDATA[
 /// await using (ComServer server = new ComServer())
 /// {
 ///     server.RegisterClass<RemoteThing, IRemoteThing>();
 ///     server.Start();
-///     await server.WaitForFirstObjectAsync();
+///     await server.WaitForEmptyAsync();
 /// }
 /// ]]>
 /// </code>
@@ -228,6 +228,33 @@ public sealed class ComServer : IAsyncDisposable
         firstInstanceCreated = null;
         lifetimeCheckTimer.Stop();
         CoSuspendClassObjects().ThrowOnFailure();
+    }
+
+    /// <summary>
+    /// Wait for all objects created by the server to be deallocated.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task"/> to await.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">The instance is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Start"/> has not yet been called.</exception>
+    public async Task WaitForEmptyAsync()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        if (!lifetimeCheckTimer.Enabled)
+        {
+            throw new InvalidOperationException("WaitForEmptyAsync() cannot be called if the ComServer is stopped");
+        }
+
+        TaskCompletionSource taskCompletionSource = new();
+        void OnEmpty(object? sender, EventArgs e)
+        {
+            taskCompletionSource.SetResult();
+        }
+
+        Empty += OnEmpty;
+        await taskCompletionSource.Task.ConfigureAwait(false);
+        Empty -= OnEmpty;
     }
 
     /// <summary>

--- a/src/Shmuelie.WinRTServer/ComServer.cs
+++ b/src/Shmuelie.WinRTServer/ComServer.cs
@@ -323,15 +323,7 @@ public sealed class ComServer : IAsyncDisposable
 
                 if (liveServers.Count != 0)
                 {
-                    TaskCompletionSource<bool> tcs = new();
-                    void Ended(object? sender, EventArgs e)
-                    {
-                        tcs.SetResult(true);
-                    }
-
-                    Empty += Ended;
-                    await tcs.Task.ConfigureAwait(false);
-                    Empty -= Ended;
+                    await WaitForEmptyAsync().ConfigureAwait(false);
                 }
 
                 lifetimeCheckTimer.Stop();

--- a/src/Shmuelie.WinRTServer/WinRtServer.cs
+++ b/src/Shmuelie.WinRTServer/WinRtServer.cs
@@ -20,14 +20,14 @@ namespace Shmuelie.WinRTServer;
 /// </summary>
 /// <remarks>
 /// <para>Allows for types to be created using WinRT activation instead of COM activation like <see cref="ComServer"/>.</para>
-/// <para>Typical usage is to call from an <see langword="await"/> <see langword="using"/> block, using <see cref="WaitForFirstObjectAsync"/> to not close until it is safe to do so.</para>
+/// <para>Typical usage is to call from an <see langword="await"/> <see langword="using"/> block, using <see cref="WaitForEmptyAsync"/> to not close until it is safe to do so.</para>
 /// <code language="cs">
 /// <![CDATA[
 /// await using (WinRtServer server = new WinRtServer())
 /// {
 ///     server.RegisterClass<RemoteThing>();
 ///     server.Start();
-///     await server.WaitForFirstObjectAsync();
+///     await server.WaitForEmptyAsync();
 /// }
 /// ]]>
 /// </code>
@@ -298,6 +298,33 @@ public sealed class WinRtServer : IAsyncDisposable
 
         firstInstanceCreated = null;
         lifetimeCheckTimer.Stop();
+    }
+
+    /// <summary>
+    /// Wait for all objects created by the server to be deallocated.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task"/> to await.
+    /// </returns>
+    /// <exception cref="ObjectDisposedException">The instance is disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <see cref="Start"/> has not yet been called.</exception>
+    public async Task WaitForEmptyAsync()
+    {
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+        if (!IsRunning)
+        {
+            throw new InvalidOperationException("WaitForEmptyAsync() cannot be called if the WinRtServer is stopped");
+        }
+
+        TaskCompletionSource taskCompletionSource = new();
+        void OnEmpty(object? sender, EventArgs e)
+        {
+            taskCompletionSource.SetResult();
+        }
+
+        Empty += OnEmpty;
+        await taskCompletionSource.Task.ConfigureAwait(false);
+        Empty -= OnEmpty;
     }
 
     /// <summary>

--- a/src/Shmuelie.WinRTServer/WinRtServer.cs
+++ b/src/Shmuelie.WinRTServer/WinRtServer.cs
@@ -378,15 +378,7 @@ public sealed class WinRtServer : IAsyncDisposable
             {
                 if (liveServers.Count != 0)
                 {
-                    TaskCompletionSource<bool> tcs = new();
-                    void Ended(object? sender, EventArgs e)
-                    {
-                        tcs.SetResult(true);
-                    }
-
-                    Empty += Ended;
-                    await tcs.Task.ConfigureAwait(false);
-                    Empty -= Ended;
+                    await WaitForEmptyAsync().ConfigureAwait(false);
                 }
 
                 lifetimeCheckTimer.Stop();


### PR DESCRIPTION
This method waits until the timed check says there are no objects left being vended through the server. This solves the issue described in #45. I also updated the doc comments to utilize the new method. I have tested the ComServer version, and it does terminate the process as expected. I have not tested the WinRtServer version, but since the two classes are so similar, I expect it will work as well.